### PR TITLE
add softmax backward kernel

### DIFF
--- a/oneflow/cambricon/cnnl/cnnl_tensor_descriptor.cpp
+++ b/oneflow/cambricon/cnnl/cnnl_tensor_descriptor.cpp
@@ -150,7 +150,7 @@ void CnnlTensorDescriptor::set_additional_dim(const user_op::Tensor* t, std::vec
                                           dims.data(), stride_info.data()));
 }
 
-void CnnlTensorDescriptor::set_reshape(const user_op::Tensor* t, std::vector<int>& dims) {
+void CnnlTensorDescriptor::set_reshape(const user_op::Tensor* t, const std::vector<int>& dims) {
   // TODO(WangYi): support non contiguous tensor.
   CHECK_OR_THROW(one::IsContiguous(t->shape_view(), t->stride()))
       << "set_reshape(): tensor must be contiguous";
@@ -160,7 +160,7 @@ void CnnlTensorDescriptor::set_reshape(const user_op::Tensor* t, std::vector<int
   int value = 1;
   for (size_t i = dim - 1; i > 0; --i) {
     stride_info[i] = value;
-    value *= dims[i];
+    value *= dims.at(i);
   }
   stride_info[0] = value;
   OF_CNNL_CHECK(cnnlSetTensorDescriptorEx(this->mut_desc(), CNNL_LAYOUT_NCHW, data_type, dim,

--- a/oneflow/cambricon/cnnl/cnnl_tensor_descriptor.h
+++ b/oneflow/cambricon/cnnl/cnnl_tensor_descriptor.h
@@ -64,7 +64,7 @@ class CnnlTensorDescriptor : public CnnlDescriptor<cnnlTensorStruct, &cnnlCreate
 
   // set_additional_dim will change layout (i.e. NCHW -> NHWC)
   // `set_reshape` only modify shape and stride
-  void set_reshape(const user_op::Tensor* t, std::vector<int>& dims);
+  void set_reshape(const user_op::Tensor* t, const std::vector<int>& dims);
 
   template<typename T>
   void set(const user_op::Tensor* t, const std::vector<T>& shape_info,

--- a/oneflow/cambricon/kernels/log_softmax_kernel.cpp
+++ b/oneflow/cambricon/kernels/log_softmax_kernel.cpp
@@ -72,4 +72,54 @@ class MluLogSoftmaxKernel final : public user_op::OpKernel {
 REGISTER_LOG_SOFTMAX_MLU_KERNEL(float)
 REGISTER_LOG_SOFTMAX_MLU_KERNEL(float16)
 
+template<typename T>
+class MluLogSoftmaxGradKernel final : public user_op::OpKernel {
+ public:
+  MluLogSoftmaxGradKernel() = default;
+  ~MluLogSoftmaxGradKernel() = default;
+
+ private:
+  using user_op::OpKernel::Compute;
+
+  void Compute(user_op::KernelComputeContext* ctx) const override {
+    const user_op::Tensor* prob = ctx->Tensor4ArgNameAndIndex("prob", 0);
+    const user_op::Tensor* dy = ctx->Tensor4ArgNameAndIndex("dy", 0);
+    user_op::Tensor* dx = ctx->Tensor4ArgNameAndIndex("dx", 0);
+
+    int prob_ndim = prob->shape_view().NumAxes();
+    int batch_dims = prob->shape_view().Count(0, prob_ndim - 1);
+    int softmax_dim = prob->shape_view().At(prob_ndim - 1);
+
+    CnnlTensorDescriptor prob_desc, dy_desc, dx_desc;
+    std::vector<int> addentional_dims = {batch_dims, 1, softmax_dim};
+    prob_desc.set_reshape(prob, addentional_dims);
+    dy_desc.set_reshape(dy, addentional_dims);
+    dx_desc.set_reshape(dx, addentional_dims);
+
+    cnnlSoftmaxBackward(
+        /* handle      */ ctx->stream()->As<ep::MluStream>()->cnnl_handle(),
+        /* algorithm   */ CNNL_SOFTMAX_LOG,
+        /* mode        */ CNNL_SOFTMAX_MODE_LOW_DIMENSION,
+        /* alpha       */ nullptr,
+        /* y_desc      */ prob_desc.desc(),
+        /* y           */ prob->dptr(),
+        /* diff_y_desc */ dy_desc.desc(),
+        /* diff_y      */ dy->dptr(),
+        /* beta        */ nullptr,
+        /* diff_x_desc */ dx_desc.desc(),
+        /* diff_x      */ dx->mut_dptr());
+  }
+
+  bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
+};
+
+#define REGISTER_LOG_SOFTMAX_GRAD_MLU_KERNEL(dtype)                        \
+  REGISTER_USER_KERNEL("log_softmax_grad")                                 \
+      .SetCreateFn<MluLogSoftmaxGradKernel<dtype>>()                      \
+      .SetIsMatchedHob((user_op::HobDeviceType() == DeviceType::kMLU) \
+                       && (user_op::HobDataType("prob", 0) == GetDataType<dtype>::value));
+
+REGISTER_LOG_SOFTMAX_GRAD_MLU_KERNEL(float)
+REGISTER_LOG_SOFTMAX_GRAD_MLU_KERNEL(float16)
+
 }  // namespace oneflow

--- a/oneflow/cambricon/kernels/log_softmax_kernel.cpp
+++ b/oneflow/cambricon/kernels/log_softmax_kernel.cpp
@@ -42,10 +42,9 @@ class MluLogSoftmaxKernel final : public user_op::OpKernel {
     int batch_dims = in->shape_view().Count(0, in_ndim - 1);
     int softmax_dim = in->shape_view().At(in_ndim - 1);
 
-    std::vector<int> addentional_dims_input = {batch_dims, 1, softmax_dim};
-    std::vector<int> addentional_dims_output = {batch_dims, 1, softmax_dim};
-    input_desc.set_reshape(in, addentional_dims_input);
-    output_desc.set_reshape(out, addentional_dims_output);
+    std::vector<int> addentional_dims = {batch_dims, 1, softmax_dim};
+    input_desc.set_reshape(in, addentional_dims);
+    output_desc.set_reshape(out, addentional_dims);
 
     OF_CNNL_CHECK(cnnlSoftmaxForward_v2(
         /* handle    */ ctx->stream()->As<ep::MluStream>()->cnnl_handle(),

--- a/oneflow/cambricon/kernels/softmax_kernel.cpp
+++ b/oneflow/cambricon/kernels/softmax_kernel.cpp
@@ -41,10 +41,9 @@ class MluSoftmaxKernel final : public user_op::OpKernel {
     int batch_dims = in->shape_view().Count(0, in_ndim - 1);
     int softmax_dim = in->shape_view().At(in_ndim - 1);
 
-    std::vector<int> addentional_dims_input = {batch_dims, 1, softmax_dim};
-    std::vector<int> addentional_dims_output = {batch_dims, 1, softmax_dim};
-    input_desc.set_reshape(in, addentional_dims_input);
-    output_desc.set_reshape(out, addentional_dims_output);
+    std::vector<int> addentional_dims = {batch_dims, 1, softmax_dim};
+    input_desc.set_reshape(in, addentional_dims);
+    output_desc.set_reshape(out, addentional_dims);
 
     OF_CNNL_CHECK(cnnlSoftmaxForward_v2(
         /* handle    */ ctx->stream()->As<ep::MluStream>()->cnnl_handle(),
@@ -70,4 +69,52 @@ class MluSoftmaxKernel final : public user_op::OpKernel {
 REGISTER_SOFTMAX_MLU_KERNEL(float)
 REGISTER_SOFTMAX_MLU_KERNEL(float16)
 
+template<typename T>
+class MluSoftmaxGradKernel final : public user_op::OpKernel {
+ public:
+  MluSoftmaxGradKernel() = default;
+  ~MluSoftmaxGradKernel() = default;
+
+ private:
+  using user_op::OpKernel::Compute;
+
+  void Compute(user_op::KernelComputeContext* ctx) const override {
+    const user_op::Tensor* y = ctx->Tensor4ArgNameAndIndex("y", 0);
+    const user_op::Tensor* dy = ctx->Tensor4ArgNameAndIndex("dy", 0);
+    user_op::Tensor* dx = ctx->Tensor4ArgNameAndIndex("dx", 0);
+    int y_ndim = y->shape_view().NumAxes();
+    int batch_dims = y->shape_view().Count(0, y_ndim - 1);
+    int softmax_dim = y->shape_view().At(y_ndim - 1);
+
+    CnnlTensorDescriptor y_desc, dy_desc, dx_desc;
+    std::vector<int> addentional_dims_y = {batch_dims, 1, softmax_dim};
+    y_desc.set_reshape(y, addentional_dims_y);
+    dy_desc.set_reshape(dy, addentional_dims_y);
+    dx_desc.set_reshape(dx, addentional_dims_y);
+
+    cnnlSoftmaxBackward(
+        /* handle      */ ctx->stream()->As<ep::MluStream>()->cnnl_handle(),
+        /* algorithm   */ CNNL_SOFTMAX_ACCURATE,
+        /* mode        */ CNNL_SOFTMAX_MODE_LOW_DIMENSION,
+        /* alpha       */ nullptr,
+        /* y_desc      */ y_desc.desc(),
+        /* y           */ y->dptr(),
+        /* diff_y_desc */ dy_desc.desc(),
+        /* diff_y      */ dy->dptr(),
+        /* beta        */ nullptr,
+        /* diff_x_desc */ dx_desc.desc(),
+        /* diff_x      */ dx->mut_dptr());
+  }
+
+  bool AlwaysComputeWhenAllOutputsEmpty() const override { return false; }
+};
+
+#define REGISTER_SOFTMAX_GRAD_MLU_KERNEL(dtype)                       \
+  REGISTER_USER_KERNEL("softmax_grad")                                \
+      .SetCreateFn<MluSoftmaxGradKernel<dtype>>()                     \
+      .SetIsMatchedHob((user_op::HobDeviceType() == DeviceType::kMLU) \
+                       && (user_op::HobDataType("y", 0) == GetDataType<dtype>::value));
+
+REGISTER_SOFTMAX_GRAD_MLU_KERNEL(float)
+REGISTER_SOFTMAX_GRAD_MLU_KERNEL(float16)
 }  // namespace oneflow

--- a/oneflow/cambricon/kernels/softmax_kernel.cpp
+++ b/oneflow/cambricon/kernels/softmax_kernel.cpp
@@ -87,10 +87,10 @@ class MluSoftmaxGradKernel final : public user_op::OpKernel {
     int softmax_dim = y->shape_view().At(y_ndim - 1);
 
     CnnlTensorDescriptor y_desc, dy_desc, dx_desc;
-    std::vector<int> addentional_dims_y = {batch_dims, 1, softmax_dim};
-    y_desc.set_reshape(y, addentional_dims_y);
-    dy_desc.set_reshape(dy, addentional_dims_y);
-    dx_desc.set_reshape(dx, addentional_dims_y);
+    std::vector<int> addentional_dims = {batch_dims, 1, softmax_dim};
+    y_desc.set_reshape(y, addentional_dims);
+    dy_desc.set_reshape(dy, addentional_dims);
+    dx_desc.set_reshape(dx, addentional_dims);
 
     cnnlSoftmaxBackward(
         /* handle      */ ctx->stream()->As<ep::MluStream>()->cnnl_handle(),

--- a/python/oneflow/test/cambricon/test_softmax.py
+++ b/python/oneflow/test/cambricon/test_softmax.py
@@ -39,7 +39,7 @@ def _test_softmax_forward(test_case, shape, device, dtype):
         )
 
 
-def _test_softmax_backward(test_case, shape, device, dtype):
+def _test_softmax_backward(test_case, shape, dtype):
     x_np = np.random.randn(*shape)
     y_grad_np = np.random.randn(*shape)
 
@@ -113,7 +113,6 @@ class TestSoftmaxCambriconModule(flow.unittest.TestCase):
             (8, 12, 16, 24),
             (4, 8, 12, 16, 24),
         ]
-        arg_dict["device"] = ["mlu"]
         arg_dict["dtype"] = [
             flow.float32,
             flow.float16,

--- a/python/oneflow/test/cambricon/test_softmax.py
+++ b/python/oneflow/test/cambricon/test_softmax.py
@@ -39,12 +39,73 @@ def _test_softmax_forward(test_case, shape, device, dtype):
         )
 
 
+def _test_softmax_backward(test_case, shape, device, dtype):
+    x_np = np.random.randn(*shape)
+    y_grad_np = np.random.randn(*shape)
+
+    rtol = 1e-3 if dtype == flow.float16 else 1e-4
+    atol = 1e-3 if dtype == flow.float16 else 1e-4
+
+    def _get_softmax_grad(device):
+        x = flow.tensor(x_np, device=flow.device(device), dtype=dtype).requires_grad_(
+            True
+        )
+        y_grad = flow.tensor(
+            y_grad_np, device=flow.device(device), dtype=dtype
+        ).requires_grad_(True)
+        if device == "cpu":
+            x = x.float()
+            y_grad = y_grad.float()
+        y = flow.softmax(x)
+
+        dx = flow.autograd.grad(
+            outputs=y,
+            inputs=x,
+            grad_outputs=y_grad,
+            create_graph=True,
+            retain_graph=True,
+        )[0]
+
+        return dx
+
+    dx_cpu = _get_softmax_grad("cpu")
+    dx_mlu = _get_softmax_grad("mlu")
+
+    test_case.assertTrue(
+        np.allclose(
+            dx_cpu.detach().numpy(),
+            dx_mlu.detach().cpu().numpy(),
+            rtol=rtol,
+            atol=atol,
+        )
+    )
+
+
 @flow.unittest.skip_unless_1n1d()
 class TestSoftmaxCambriconModule(flow.unittest.TestCase):
     def test_softmax(test_case):
         arg_dict = OrderedDict()
         arg_dict["test_fun"] = [
             _test_softmax_forward,
+        ]
+        arg_dict["shape"] = [
+            (16, 32,),
+            (12, 16, 24),
+            (8, 12, 16, 24),
+            (4, 8, 12, 16, 24),
+        ]
+        arg_dict["device"] = ["mlu"]
+        arg_dict["dtype"] = [
+            flow.float32,
+            flow.float16,
+        ]
+        for arg in GenArgList(arg_dict):
+            arg[0](test_case, *arg[1:])
+
+    def test_softmax_grad(test_case):
+        arg_dict = OrderedDict()
+        arg_dict["test_fun"] = [
+            _test_softmax_backward,
         ]
         arg_dict["shape"] = [
             (16, 32,),


### PR DESCRIPTION
- 增加了 log_softmax / softmax 的反向接口
- 增加了 log_softmax / softmax 反向的单测
- refine 了 tensor_desc 的 set_reshape 成员函数，把 dims 改成了 const，删掉了 kernel 中多余的 shape vector

注意：log_softmax 里面单测的 atol 改成了 1e-2，可能有些大，因为 1e-3 一直挂