### PR TITLE
add testcase

### DIFF
--- a/python/oneflow/test/cambricon/test_narrow.py
+++ b/python/oneflow/test/cambricon/test_narrow.py
@@ -55,16 +55,16 @@ def _test_narrow_backward(test_case, shape, dim, start_length, device, dtype):
     x_cpu = flow.tensor(np_arr, device="cpu", dtype=dtype, requires_grad=True)
 
     mlu_out = flow.narrow(x, dim=dim, start=start_length[0], length=start_length[1])
-    cpu_out = flow.narrow(
-        x_cpu, dim=dim, start=start_length[0], length=start_length[1]
-    )
+    cpu_out = flow.narrow(x_cpu, dim=dim, start=start_length[0], length=start_length[1])
     test_case.assertTrue(np.allclose(mlu_out.numpy(), cpu_out.numpy(), 0.0001, 0.0001))
 
     np_grad = np.random.randn(*mlu_out.shape)
     mlu_out.backward(flow.tensor(np_grad, device=flow.device(device), dtype=dtype))
     cpu_out.backward(flow.tensor(np_grad, device="cpu", dtype=dtype))
 
-    test_case.assertTrue(np.allclose(x.grad.numpy(), x_cpu.grad.numpy(), 0.0001, 0.0001))
+    test_case.assertTrue(
+        np.allclose(x.grad.numpy(), x_cpu.grad.numpy(), 0.0001, 0.0001)
+    )
 
 
 @flow.unittest.skip_unless_1n1d()
@@ -90,9 +90,7 @@ class TestNarrowCambriconModule(flow.unittest.TestCase):
 
     def test_narrow_backward(test_case):
         arg_dict = OrderedDict()
-        arg_dict["test_fun"] = [
-            _test_narrow_backward
-        ]
+        arg_dict["test_fun"] = [_test_narrow_backward]
         arg_dict["shape"] = [(3, 4, 5), (6, 7, 8)]
         arg_dict["dim"] = [0, 1, 2]
         arg_dict["start_length"] = [(0, 2), (2, 1), (1, 2)]

--- a/python/oneflow/test/cambricon/test_ones_like.py
+++ b/python/oneflow/test/cambricon/test_ones_like.py
@@ -47,7 +47,7 @@ def _test_ones_like_int(test_case, shape, device):
 
 
 @flow.unittest.skip_unless_1n1d()
-class TestModule(flow.unittest.TestCase):
+class TestOnesLikeCambriconModule(flow.unittest.TestCase):
     def test_ones_like(test_case):
         arg_dict = OrderedDict()
         arg_dict["test_fun"] = [_test_ones_like_float, _test_ones_like_int]

--- a/python/oneflow/test/cambricon/test_ones_like.py
+++ b/python/oneflow/test/cambricon/test_ones_like.py
@@ -1,0 +1,61 @@
+"""
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+from collections import OrderedDict
+
+import numpy as np
+from oneflow.test_utils.test_util import GenArgList
+
+import oneflow as flow
+import oneflow.unittest
+
+
+def _test_ones_like_float(test_case, shape, device):
+    x = flow.tensor(
+        np.random.randn(*shape), dtype=flow.float32, device=flow.device(device)
+    )
+    y = flow.ones_like(x)
+    test_case.assertTrue(y.dtype is flow.float32)
+    test_case.assertTrue(y.shape == x.shape)
+    test_case.assertTrue(y.device == x.device)
+    y_numpy = np.ones_like(x.numpy())
+    test_case.assertTrue(np.array_equal(y.numpy(), y_numpy))
+
+
+def _test_ones_like_int(test_case, shape, device):
+    x = flow.tensor(np.random.randn(*shape), dtype=flow.int, device=flow.device(device))
+    y = flow.ones_like(x)
+    test_case.assertTrue(y.dtype is flow.int)
+    test_case.assertTrue(y.shape == x.shape)
+    test_case.assertTrue(y.device == x.device)
+    y_numpy = np.ones_like(x.numpy())
+    test_case.assertTrue(np.array_equal(y.numpy(), y_numpy))
+
+
+@flow.unittest.skip_unless_1n1d()
+class TestModule(flow.unittest.TestCase):
+    def test_ones_like(test_case):
+        arg_dict = OrderedDict()
+        arg_dict["test_fun"] = [_test_ones_like_float, _test_ones_like_int]
+        arg_dict["shape"] = [(2, 3), (2, 3, 4), (2, 4, 5, 6)]
+        arg_dict["device"] = ["mlu"]
+        for arg in GenArgList(arg_dict):
+            arg[0](test_case, *arg[1:])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- 由于ones_like op在kernel层完全基于fill的ep::primitive实现且mlu已适配了fill primitive，故这里无需重写ones_like的mlu kernel，此pr增加了test case