### PR TITLE
fix_conv2d_forward_NHWC_bug

### DIFF
--- a/python/oneflow/test/cambricon/test_conv2d.py
+++ b/python/oneflow/test/cambricon/test_conv2d.py
@@ -1763,6 +1763,105 @@ class TestConv2d(flow.unittest.TestCase):
             np.allclose(out_mlu.cpu().numpy(), out_cpu.numpy(), 1e-4, 1e-5)
         )
 
+    @unittest.skipIf(os.getenv("ONEFLOW_TEST_CPU_ONLY"), "only test cpu cases")
+    def test_conv2d_NHWC_with_random_data(test_case):
+        in_channels = np.random.randint(6, 33)
+        out_channels = np.random.randint(32, 66)
+        kernel_size = np.random.randint(1, 5)
+        stride = np.random.randint(1, 2)
+        padding = np.random.randint(1, 3)
+        dilation = np.random.randint(1, 3)
+        spatial = np.random.randint(6, 64)
+
+        np_x = np.random.randn(4, in_channels, spatial, spatial).astype(np.float32)
+        np_weight = np.random.randn(
+            out_channels, in_channels, kernel_size, kernel_size
+        ).astype(np.float32)
+        np_bias = np.random.randn(out_channels).astype(np.float32)
+
+        flow_nchw_input = flow.tensor(
+            np_x, device="mlu", dtype=flow.float32, requires_grad=True
+        )
+        flow_nchw_weights = flow.nn.Parameter(
+            flow.tensor(np_weight, device="mlu", dtype=flow.float32, requires_grad=True)
+        )
+        flow_nchw_bias = flow.nn.Parameter(
+            flow.tensor(np_bias, device="mlu", dtype=flow.float32, requires_grad=True)
+        )
+
+        flow_nchw_conv = flow.nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+        ).to("mlu")
+        flow_nchw_conv.weight = flow_nchw_weights
+        flow_nchw_conv.bias = flow_nchw_bias
+
+        flow_nchw_out = flow_nchw_conv(flow_nchw_input)
+
+        os.environ["ONEFLOW_ENABLE_NHWC"] = "1"
+        flow_nhwc_input = flow.tensor(
+            np_x, device="mlu", dtype=flow.float32, requires_grad=True
+        )
+        flow_nhwc_permuted_input = flow.permute(flow_nhwc_input, (0, 2, 3, 1))
+        flow_nhwc_weights = flow.tensor(
+            np_weight, device="mlu", dtype=flow.float32, requires_grad=True
+        )
+        flow_nhwc_permuted_weights = flow.nn.Parameter(
+            flow.permute(flow_nhwc_weights, (0, 2, 3, 1))
+        )
+        flow_nhwc_bias = flow.nn.Parameter(
+            flow.tensor(np_bias, device="mlu", dtype=flow.float32, requires_grad=True)
+        )
+
+        flow_nhwc_conv = flow.nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+        ).to("mlu")
+        flow_nhwc_conv.weight = flow_nhwc_permuted_weights
+        flow_nhwc_conv.bias = flow_nhwc_bias
+
+        flow_nhwc_out = flow_nhwc_conv(flow_nhwc_permuted_input)
+        flow_nhwc_permuted_out = flow.permute(flow_nhwc_out, (0, 3, 1, 2))
+
+        test_case.assertTrue(
+            np.allclose(
+                flow_nchw_out.numpy(),
+                flow_nhwc_permuted_out.numpy(),
+                rtol=1e-4,
+                atol=1e-4,
+            )
+        )
+
+        total_out = flow_nchw_out + flow_nhwc_permuted_out
+
+        total_out = total_out.sum()
+        total_out.backward()
+        test_case.assertTrue(
+            np.allclose(
+                flow_nchw_weights.grad.numpy(),
+                np.transpose(flow_nhwc_permuted_weights.grad.numpy(), (0, 3, 1, 2)),
+                rtol=1e-3,
+                atol=1e-4,
+            )
+        )
+        test_case.assertTrue(
+            np.allclose(
+                flow_nchw_input.grad.numpy(),
+                flow_nhwc_input.grad.numpy(),
+                rtol=1e-4,
+                atol=1e-4,
+            )
+        )
+        os.environ["ONEFLOW_ENABLE_NHWC"] = "0"
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/oneflow/test/cambricon/test_reciprocal.py
+++ b/python/oneflow/test/cambricon/test_reciprocal.py
@@ -29,7 +29,7 @@ def _test_reciprocal_forward(test_case, shape, device, dtype):
     arr[0] = 0
     x = flow.tensor(arr, device=flow.device(device), dtype=dtype)
     x_cpu = x.cpu()
-    
+
     of_out = flow._C.reciprocal(x_cpu)
     mlu_out = flow._C.reciprocal(x)
     test_case.assertTrue(np.allclose(mlu_out.numpy(), of_out.numpy(), 0.001, 0.001))
@@ -40,7 +40,7 @@ def _test_reciprocal_no_nan_forward(test_case, shape, device, dtype):
     arr[0] = 0
     x = flow.tensor(arr, device=flow.device(device), dtype=dtype)
     x_cpu = x.cpu()
-    
+
     of_out = flow._C.reciprocal_no_nan(x_cpu)
     mlu_out = flow._C.reciprocal_no_nan(x)
     test_case.assertTrue(np.allclose(mlu_out.numpy(), of_out.numpy(), 0.001, 0.001))
@@ -52,7 +52,7 @@ class TestReluCambriconModule(flow.unittest.TestCase):
         arg_dict = OrderedDict()
         arg_dict["test_fun"] = [
             _test_reciprocal_forward,
-            _test_reciprocal_no_nan_forward
+            _test_reciprocal_no_nan_forward,
         ]
         arg_dict["shape"] = [(2,), (2, 3), (2, 3, 4), (2, 3, 4, 5)]
         arg_dict["device"] = ["mlu"]

--- a/python/oneflow/test/cambricon/test_scalar_math_cambricon.py
+++ b/python/oneflow/test/cambricon/test_scalar_math_cambricon.py
@@ -64,6 +64,7 @@ def _test_scalar_sub_forward(test_case, shape, device, dtype):
     diff = _get_diff(dtype)
     test_case.assertTrue(np.allclose(of_out.numpy(), np_out, diff, diff))
 
+
 def _test_scalar_pow_forward(test_case, shape, device, dtype):
     if dtype == flow.int:
         return
@@ -72,7 +73,10 @@ def _test_scalar_pow_forward(test_case, shape, device, dtype):
     x_cpu = x.cpu()
     mlu_out = flow.pow(x, y)
     cpu_out = flow.pow(x_cpu, y)
-    test_case.assertTrue(np.allclose(cpu_out.numpy(), mlu_out.numpy(), 0.0001, 0.0001, equal_nan=True))
+    test_case.assertTrue(
+        np.allclose(cpu_out.numpy(), mlu_out.numpy(), 0.0001, 0.0001, equal_nan=True)
+    )
+
 
 @flow.unittest.skip_unless_1n1d()
 class TestScalarMathCambriconModule(flow.unittest.TestCase):


### PR DESCRIPTION
修复`channels_last`模式下`conv2d_forward`的错误，在打开`ONEFLOW_ENABLE_NHWC`，前向计算时`weight`不需要`permute`，修复之后，`conv2d_NHWC`测试用例可以通过。