### PR TITLE
support device_type='mlu' in CommBroadcastFunctor

### DIFF
--- a/oneflow/core/functional/impl/comm_functor.cpp
+++ b/oneflow/core/functional/impl/comm_functor.cpp
@@ -211,8 +211,7 @@ class CommBroadcastFunctor {
                            bool inplace) const {
     const auto& rank_group = JUST(RankGroupScope::CurrentRankGroup());
     std::string device_type_str = JUST(x->device())->type();
-    CHECK_OR_RETURN(device_type_str == "cuda" || device_type_str == "cpu");
-    DeviceType device_type = device_type_str == "cuda" ? DeviceType::kCUDA : DeviceType::kCPU;
+    DeviceType device_type = JUST(DeviceType4DeviceTag(device_type_str));
     const auto& parallel_desc = JUST(RankGroup::GetDefaultParallelDesc(device_type, rank_group));
     return one::Broadcast(x, src_rank, parallel_desc, inplace);
   }


### PR DESCRIPTION
在 CommBroadcastFunctor 中支持寒武纪 mlu，删除了“ device_type 只能是 cpu 或者 cuda ”的限制