### PR TITLE
adaptive avg pool 2d support data_format argument

### DIFF
--- a/oneflow/cambricon/kernels/adaptive_avg_pool_kernel.cpp
+++ b/oneflow/cambricon/kernels/adaptive_avg_pool_kernel.cpp
@@ -189,10 +189,6 @@ class AdaptiveAvgPool2DGradKernel final : public user_op::OpKernel {
 
   void ComputeNHWC(user_op::KernelComputeContext* ctx, const user_op::Tensor* dy_tensor,
                    user_op::Tensor* dx_tensor) const {
-    auto device_type = ctx->stream()->device_type();
-    if (device_type != DeviceType::kMLU) {
-      THROW(RuntimeError) << "adaptive_avg_pool2d only support NHWC on MLU now";
-    }
     auto dtype = ConvertToCnnlDataType(dy_tensor->data_type());
     CnnlTensorDescriptor dy_desc, dx_desc;
     dy_desc.set(dy_tensor->shape_view().NumAxes(), dy_tensor->shape_view().data(), dtype,

--- a/oneflow/cambricon/kernels/adaptive_avg_pool_kernel.cpp
+++ b/oneflow/cambricon/kernels/adaptive_avg_pool_kernel.cpp
@@ -188,11 +188,12 @@ class AdaptiveAvgPool2DGradKernel final : public user_op::OpKernel {
 
   void ComputeNHWC(user_op::KernelComputeContext* ctx, const user_op::Tensor* dy_tensor,
                    user_op::Tensor* dx_tensor) const {
-    cnnlTensorLayout_t layout = CNNL_LAYOUT_NHWC;
     auto dtype = ConvertToCnnlDataType(dy_tensor->data_type());
     CnnlTensorDescriptor dy_desc, dx_desc;
-    dy_desc.set(dy_tensor, layout, dtype);
-    dx_desc.set(dx_tensor, layout, dtype);
+    dy_desc.set(dy_tensor->shape_view().NumAxes(), dy_tensor->shape_view().data(), dtype,
+                CNNL_LAYOUT_NHWC);
+    dx_desc.set(dx_tensor->shape_view().NumAxes(), dx_tensor->shape_view().data(), dtype,
+                CNNL_LAYOUT_NHWC);
     OF_CNNL_CHECK(cnnlAdaptivePoolingBackward(ctx->stream()->As<ep::MluStream>()->cnnl_handle(),
                                               dy_desc.desc(), dy_tensor->dptr(), nullptr, nullptr,
                                               CNNL_POOLING_AVERAGE_COUNT_INCLUDE_PADDING,

--- a/oneflow/cambricon/kernels/adaptive_avg_pool_kernel.cpp
+++ b/oneflow/cambricon/kernels/adaptive_avg_pool_kernel.cpp
@@ -188,7 +188,11 @@ class AdaptiveAvgPool2DGradKernel final : public user_op::OpKernel {
 
   void ComputeNHWC(user_op::KernelComputeContext* ctx, const user_op::Tensor* dy_tensor,
                    user_op::Tensor* dx_tensor) const {
-    CnnlTensorDescriptor dy_desc(dy_tensor), dx_desc(dx_tensor);
+    cnnlTensorLayout_t layout = CNNL_LAYOUT_NHWC;
+    auto dtype = ConvertToCnnlDataType(dy_tensor->data_type());
+    CnnlTensorDescriptor dy_desc, dx_desc;
+    dy_desc.set(dy_tensor, layout, dtype);
+    dx_desc.set(dx_tensor, layout, dtype);
     OF_CNNL_CHECK(cnnlAdaptivePoolingBackward(ctx->stream()->As<ep::MluStream>()->cnnl_handle(),
                                               dy_desc.desc(), dy_tensor->dptr(), nullptr, nullptr,
                                               CNNL_POOLING_AVERAGE_COUNT_INCLUDE_PADDING,

--- a/oneflow/cambricon/kernels/adaptive_avg_pool_kernel.cpp
+++ b/oneflow/cambricon/kernels/adaptive_avg_pool_kernel.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include "oneflow/cambricon/cnnl/cnnl_tensor_descriptor.h"
 #include "oneflow/core/common/data_type.h"
 #include "oneflow/core/common/data_type.pb.h"
+#include "oneflow/core/common/device_type.pb.h"
 #include "oneflow/core/common/util.h"
 #include "oneflow/core/framework/framework.h"
 #include "oneflow/core/kernel/new_kernel_util.h"
@@ -188,6 +189,10 @@ class AdaptiveAvgPool2DGradKernel final : public user_op::OpKernel {
 
   void ComputeNHWC(user_op::KernelComputeContext* ctx, const user_op::Tensor* dy_tensor,
                    user_op::Tensor* dx_tensor) const {
+    auto device_type = ctx->stream()->device_type();
+    if (device_type != DeviceType::kMLU) {
+      THROW(RuntimeError) << "adaptive_avg_pool2d only support NHWC on MLU now";
+    }
     auto dtype = ConvertToCnnlDataType(dy_tensor->data_type());
     CnnlTensorDescriptor dy_desc, dx_desc;
     dy_desc.set(dy_tensor->shape_view().NumAxes(), dy_tensor->shape_view().data(), dtype,

--- a/oneflow/core/autograd/higher_order_gradient_funcs/avg_pool.cpp
+++ b/oneflow/core/autograd/higher_order_gradient_funcs/avg_pool.cpp
@@ -33,11 +33,12 @@ template<int ndims>
 class AdaptiveAvgPoolNdNdGradGrad
     : public OpExprGradFunction<AdaptiveAvgPoolNDGradGradCaptureState> {
  public:
-  Maybe<void> Init(const OpExpr& op) override { 
+  Maybe<void> Init(const OpExpr& op) override {
     const auto* fw_op_expr = dynamic_cast<const UserOpExpr*>(&op);
     CHECK_NOTNULL_OR_RETURN(fw_op_expr);  // NOLINT(maybe-need-error-msg)
     base_attrs_ = MakeAttrMapFromUserOpConf(fw_op_expr->proto());
-    return Maybe<void>::Ok(); }
+    return Maybe<void>::Ok();
+  }
 
   Maybe<void> Capture(AdaptiveAvgPoolNDGradGradCaptureState* ctx, const TensorTuple& inputs,
                       const TensorTuple& outputs, const AttrMap& attrs) const override {
@@ -74,11 +75,14 @@ class AdaptiveAvgPoolNdNdGradGrad
 
     if (ctx->grad_requires_grad) {
       if (ndims == 1) {
-        (*in_grads)[0] = JUST(functional::AdaptiveAvgPool1D(out_grads[0], ctx->pool_output_size, ctx->data_format));
+        (*in_grads)[0] = JUST(
+            functional::AdaptiveAvgPool1D(out_grads[0], ctx->pool_output_size, ctx->data_format));
       } else if (ndims == 2) {
-        (*in_grads)[0] = JUST(functional::AdaptiveAvgPool2D(out_grads[0], ctx->pool_output_size, ctx->data_format));
+        (*in_grads)[0] = JUST(
+            functional::AdaptiveAvgPool2D(out_grads[0], ctx->pool_output_size, ctx->data_format));
       } else if (ndims == 3) {
-        (*in_grads)[0] = JUST(functional::AdaptiveAvgPool3D(out_grads[0], ctx->pool_output_size, ctx->data_format));
+        (*in_grads)[0] = JUST(
+            functional::AdaptiveAvgPool3D(out_grads[0], ctx->pool_output_size, ctx->data_format));
       } else {
         UNIMPLEMENTED_THEN_RETURN();
       }

--- a/oneflow/core/framework/op_interpreter/eager_local_op_interpreter.cpp
+++ b/oneflow/core/framework/op_interpreter/eager_local_op_interpreter.cpp
@@ -315,7 +315,8 @@ Maybe<void> RawLocalToGlobal(const LocalToGlobalOpExpr& op_expr, const TensorTup
     const auto& logical_shape = JUST(ctx.attrs.GetAttr<Shape>("shape"));
     DataType dtype = JUST(ctx.attrs.GetAttr<DataType>("dtype"));
     // MemoryFormat memory_format = JUST(ctx.attrs.GetAttr<MemoryFormat>("memory_format"));
-    GlobalTensorMeta tensor_meta(logical_shape, dtype, MemoryFormat::kUnused, nd_sbp, parallel_desc);
+    GlobalTensorMeta tensor_meta(logical_shape, dtype, MemoryFormat::kUnused, nd_sbp,
+                                 parallel_desc);
     Optional<int64_t> parallel_id{};
     const auto& device = JUST(GetTensorDevice4CurrentProcessCtx(parallel_desc, &parallel_id));
     const auto& global_tensor_impl = JUST(EagerGlobalTensorImpl::New(

--- a/oneflow/core/functional/functional_api.yaml
+++ b/oneflow/core/functional/functional_api.yaml
@@ -1533,7 +1533,7 @@
   bind_python: True
 
 - name: "adaptive_pool_grad"
-  signature: "Tensor (Tensor x, Tensor dy, String mode, Int32 ndims) => AdaptivePoolNdGrad"
+  signature: 'Tensor (Tensor x, Tensor dy, String mode, Int32 ndims, String data_format="channels_first") => AdaptivePoolNdGrad'
 
 - name: "tf_pool_grad"
   signature:

--- a/oneflow/core/functional/impl/nn_functor.cpp
+++ b/oneflow/core/functional/impl/nn_functor.cpp
@@ -1260,6 +1260,9 @@ class AdaptivePoolNDFunctor {
   Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x,
                            const std::vector<int64_t>& output_size,
                            const std::string& data_format) const {
+    if (data_format == "channels_last" && JUST(x->device())->enum_type() != DeviceType::kMLU) {
+      THROW(RuntimeError) << "adaptive_avg_pool supports NHWC only on MLU";
+    }
     auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("output_size", "data_format");
     attrs.SetAllAttrs(output_size, data_format);
     return OpInterpUtil::Dispatch<Tensor>(*op_, {x}, attrs);

--- a/oneflow/core/functional/impl/nn_functor.cpp
+++ b/oneflow/core/functional/impl/nn_functor.cpp
@@ -1258,7 +1258,8 @@ class AdaptivePoolNDFunctor {
   AdaptivePoolNDFunctor() = default;
   virtual ~AdaptivePoolNDFunctor() = default;
   Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x,
-                           const std::vector<int64_t>& output_size, const std::string& data_format) const {
+                           const std::vector<int64_t>& output_size,
+                           const std::string& data_format) const {
     auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("output_size", "data_format");
     attrs.SetAllAttrs(output_size, data_format);
     return OpInterpUtil::Dispatch<Tensor>(*op_, {x}, attrs);

--- a/oneflow/core/functional/impl/nn_grad_functor.cpp
+++ b/oneflow/core/functional/impl/nn_grad_functor.cpp
@@ -261,14 +261,16 @@ class AdaptivePoolNdGradFunctor {
   }
   Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x,
                            const std::shared_ptr<one::Tensor>& dy, const std::string& mode,
-                           const int32_t& ndims) const {
+                           const int32_t& ndims, const std::string& data_format) const {
     const auto& op_type_name = GetOpTypeName(mode, ndims);
     const auto& it = op_expr_map_.find(op_type_name);
     CHECK_OR_RETURN(it != op_expr_map_.end())
         << Error::RuntimeError() << "Encounter unsupported op " << op_type_name
         << " in AdaptivePoolNdGradFunctor.";
     CHECK_NOTNULL_OR_RETURN(it->second);  // NOLINT(maybe-need-error-msg)
-    return OpInterpUtil::Dispatch<Tensor>(*it->second, {dy, x});
+    auto& attrs = THREAD_CACHED_MUTABLE_ATTR_MAP("data_format");
+    attrs.SetAllAttrs(data_format);
+    return OpInterpUtil::Dispatch<Tensor>(*it->second, {dy, x}, attrs);
   }
 
  protected:

--- a/oneflow/core/functional/impl/nn_grad_functor.cpp
+++ b/oneflow/core/functional/impl/nn_grad_functor.cpp
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include "fmt/core.h"
+#include "oneflow/core/common/device_type.pb.h"
 #include "oneflow/core/framework/mutable_attr_map.h"
 #include "oneflow/core/framework/op_builder.h"
 #include "oneflow/core/functional/function_library.h"
@@ -262,6 +263,9 @@ class AdaptivePoolNdGradFunctor {
   Maybe<Tensor> operator()(const std::shared_ptr<one::Tensor>& x,
                            const std::shared_ptr<one::Tensor>& dy, const std::string& mode,
                            const int32_t& ndims, const std::string& data_format) const {
+    if (data_format == "channels_last" && JUST(x->device())->enum_type() != DeviceType::kMLU) {
+      THROW(RuntimeError) << "adaptive_avg_pool supports NHWC only on MLU";
+    }
     const auto& op_type_name = GetOpTypeName(mode, ndims);
     const auto& it = op_expr_map_.find(op_type_name);
     CHECK_OR_RETURN(it != op_expr_map_.end())

--- a/oneflow/ir/include/OneFlow/OneFlowBase.td
+++ b/oneflow/ir/include/OneFlow/OneFlowBase.td
@@ -381,6 +381,7 @@ class OneFlow_AdaptivePoolGradBaseOp<string mnemonic, list<Trait> traits = []> :
   );
   let output = (outs AnyType:$dx);
   let attrs = (ins
+    StrAttr:$data_format,
     SI64ArrayAttr:$output_size
   );
   let has_logical_tensor_desc_infer_fn = 1;

--- a/python/oneflow/nn/modules/pooling.py
+++ b/python/oneflow/nn/modules/pooling.py
@@ -737,11 +737,13 @@ class AdaptiveAvgPool2d(Module):
 
     """
 
-    def __init__(self, output_size) -> None:
+    def __init__(self, output_size, data_format=None) -> None:
         super().__init__()
         assert output_size is not None, "'output_size' cannot be NoneType"
         self.output_size = _pair(output_size)
-        if os.getenv("ONEFLOW_ENABLE_NHWC") == "1":
+        if data_format:
+            self.channel_pos = data_format
+        elif os.getenv("ONEFLOW_ENABLE_NHWC") == "1":
             self.channel_pos = "channels_last"
         else:
             self.channel_pos = "channels_first"
@@ -762,7 +764,7 @@ class AdaptiveAvgPool2d(Module):
         )
 
 
-def adaptive_avg_pool2d(input, output_size):
+def adaptive_avg_pool2d(input, output_size, data_format=None):
     """Applies a 2D adaptive average pooling over an input signal composed of several input planes.
 
     See :mod:`oneflow.nn.AdaptiveAvgPool2d`
@@ -771,7 +773,7 @@ def adaptive_avg_pool2d(input, output_size):
         input: input tensor
         output_size: the target output size (single integer or double-integer tuple)
     """
-    return AdaptiveAvgPool2d(output_size)(input)
+    return AdaptiveAvgPool2d(output_size, data_format)(input)
 
 
 class AdaptiveAvgPool3d(Module):

--- a/python/oneflow/nn/modules/pooling.py
+++ b/python/oneflow/nn/modules/pooling.py
@@ -757,7 +757,9 @@ class AdaptiveAvgPool2d(Module):
             len(x.shape) == 4
         ), f"expected 4-dimensional tensor, but got {len(x.shape)}-dimensional tensor"
         new_output_size = _generate_output_size(x.shape, self.output_size)
-        return flow._C.adaptive_avg_pool2d(x, output_size=new_output_size, data_format=self.channel_pos)
+        return flow._C.adaptive_avg_pool2d(
+            x, output_size=new_output_size, data_format=self.channel_pos
+        )
 
 
 def adaptive_avg_pool2d(input, output_size):

--- a/python/oneflow/test/cambricon/test_adaptive_avg_pool2d.py
+++ b/python/oneflow/test/cambricon/test_adaptive_avg_pool2d.py
@@ -46,12 +46,37 @@ def _test_adaptive_avg_pool2d_forward_backward(
     )
 
 
+def _test_adaptive_avg_pool2d_forward_backward_channels_last(
+    test_case, shape, out_shape, device, dtype
+):
+    """compare cpu channels_first with mlu channels_last"""
+    arry = np.random.randn(*shape)
+    x = flow.tensor(arry, device=flow.device(device), dtype=dtype).to(memory_format=flow.channels_last).requires_grad_(True)
+    x_cpu = flow.tensor(
+        arry, device=flow.device("cpu"), dtype=dtype, requires_grad=True
+    )
+    pool = flow.nn.AdaptiveAvgPool2d((out_shape[2], out_shape[3]))
+    pool_channels_last = flow.nn.AdaptiveAvgPool2d((out_shape[2], out_shape[3]), data_format="channels_last")
+    y = pool_channels_last(x)
+    y_cpu = pool(x_cpu)
+    test_case.assertTrue(np.allclose(flow.transpose(y, (0, 3, 1, 2)).numpy(), y_cpu.numpy(), 0.0001, 0.0001))
+
+    s = y.sum()
+    s_cpu = y_cpu.sum()
+    s.backward()
+    s_cpu.backward()
+    test_case.assertTrue(
+        np.allclose(flow.transpose(x.grad, (0, 3, 1, 2)).numpy(), x_cpu.grad.numpy(), 0.0001, 0.0001)
+    )
+
+
 @flow.unittest.skip_unless_1n1d()
 class TestAdaptiveAvgPool2dCambriconModule(flow.unittest.TestCase):
     def test_adaptive_avg_pool2d_forward_backward(test_case):
         arg_dict = OrderedDict()
         arg_dict["test_fun"] = [
             _test_adaptive_avg_pool2d_forward_backward,
+            _test_adaptive_avg_pool2d_forward_backward_channels_last,
         ]
         arg_dict["shape"] = [(1, 2, 224, 224), (1, 3, 128, 128)]
         arg_dict["out_shape"] = [(1, 2, 64, 64), (1, 3, 32, 35)]

--- a/python/oneflow/test/cambricon/test_adaptive_avg_pool2d.py
+++ b/python/oneflow/test/cambricon/test_adaptive_avg_pool2d.py
@@ -51,22 +51,37 @@ def _test_adaptive_avg_pool2d_forward_backward_channels_last(
 ):
     """compare cpu channels_first with mlu channels_last"""
     arry = np.random.randn(*shape)
-    x = flow.tensor(arry, device=flow.device(device), dtype=dtype).to(memory_format=flow.channels_last).requires_grad_(True)
+    x = (
+        flow.tensor(arry, device=flow.device(device), dtype=dtype)
+        .to(memory_format=flow.channels_last)
+        .requires_grad_(True)
+    )
     x_cpu = flow.tensor(
         arry, device=flow.device("cpu"), dtype=dtype, requires_grad=True
     )
     pool = flow.nn.AdaptiveAvgPool2d((out_shape[2], out_shape[3]))
-    pool_channels_last = flow.nn.AdaptiveAvgPool2d((out_shape[2], out_shape[3]), data_format="channels_last")
+    pool_channels_last = flow.nn.AdaptiveAvgPool2d(
+        (out_shape[2], out_shape[3]), data_format="channels_last"
+    )
     y = pool_channels_last(x)
     y_cpu = pool(x_cpu)
-    test_case.assertTrue(np.allclose(flow.transpose(y, (0, 3, 1, 2)).numpy(), y_cpu.numpy(), 0.0001, 0.0001))
+    test_case.assertTrue(
+        np.allclose(
+            flow.transpose(y, (0, 3, 1, 2)).numpy(), y_cpu.numpy(), 0.0001, 0.0001
+        )
+    )
 
     s = y.sum()
     s_cpu = y_cpu.sum()
     s.backward()
     s_cpu.backward()
     test_case.assertTrue(
-        np.allclose(flow.transpose(x.grad, (0, 3, 1, 2)).numpy(), x_cpu.grad.numpy(), 0.0001, 0.0001)
+        np.allclose(
+            flow.transpose(x.grad, (0, 3, 1, 2)).numpy(),
+            x_cpu.grad.numpy(),
+            0.0001,
+            0.0001,
+        )
     )
 
 


### PR DESCRIPTION
测试用例是 python/oneflow/test/cambricon/test_adaptive_avg_pool2d.py 中的 _test_adaptive_avg_pool2d_forward_backward_channels_last。
对比的是 cpu channels_first 和 mlu channels_last，mlu 的结果 transpose 后再对比。